### PR TITLE
Note about having a project created and select

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 * Web browser
 * Google cloud account (there's a $300 credit, free tier if you don't already have one https://cloud.google.com/free/)
+* A Google cloud project (select your project with `gcloud config set project PROJECT_ID` once Cloud Shell is ready)
 
 ## Installing JX on GKE
 


### PR DESCRIPTION
if you don't select a project before starting `jx create cluster --skip-login` you'll get an error:

```
ERROR: (gcloud.config.set) The project property must be set to a valid project ID, not the project name [Listed]
To set your project, run:
  $ gcloud config set project PROJECT_ID
or to unset it, run:
  $ gcloud config unset project
Error: Command failed  gcloud config set project Listed
error creating cluster exit status 1
error: exit status 1
```