### PR TITLE
Add info note when promoting an application

### DIFF
--- a/tutorials/install-jx-on-gke-with-terraform/lesson.md
+++ b/tutorials/install-jx-on-gke-with-terraform/lesson.md
@@ -122,6 +122,7 @@ production.
 ```bash
 cd cloudshell-tutorial
 ```
+_If you have 2FA enabled on your GitHub account, then you may need to use an api token as your password when prompted._
 
 ```bash
 jx promote cloudshell-tutorial --version 0.0.1 --env production


### PR DESCRIPTION
If you have 2FA enabled and the git repo has been cloned over https then the normal password flow fails as it's unable to prompt for the 2FA device/code. However, if you use an API token then 2FA is not required. See #39 for more information