### PR TITLE
Fix initial installation jx execution

### DIFF
--- a/install-guide.txt
+++ b/install-guide.txt
@@ -7,6 +7,6 @@
 To get started, you will need to install all required dependencies.  To do this
 run the script:
 
-eval "$(./install-jx.sh)" to install jx and add it to you path.
+`./install-jx.sh` to install jx and add it to you path.
 
 Enjoy...

--- a/install-jx.sh
+++ b/install-jx.sh
@@ -4,16 +4,19 @@ JX_VERSION=1.3.971
 
 function install_dependencies() {
     mkdir -p ~/bin
+    echo "Downloading & installing Jenkins X ${JX_VERSION}"
     curl -sL https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-linux-amd64.tar.gz \
     | tar xvz -C ~/bin
+    echo "Installed"
 }
 
 function add_path_to_bashrc() {
     if grep -q PATH ~/.bashrc; then
-        echo ""
+        echo "Already on path"
     else
         echo "export PATH=$PATH:$HOME/bin:$HOME/.jx/bin" >> ~/.bashrc
-        echo "export PATH=$PATH:$HOME/bin:$HOME/.jx/bin"
+        export PATH=$PATH:$HOME/bin:$HOME/.jx/bin
+        jx --help
     fi
 }
 

--- a/tutorials/install-jx-on-gke-with-terraform/lesson.md
+++ b/tutorials/install-jx-on-gke-with-terraform/lesson.md
@@ -13,7 +13,7 @@ Click the **Continue** button to move to the next step.
 The first thing we need to do is install the `jx` binary and add it to your PATH.
 
 ```bash
-eval "$(./install-jx.sh)"
+./install-jx.sh
 ```
 
 **Tip**: Click the copy button on the side of the code box and paste the command in the Cloud Shell terminal to run it.

--- a/tutorials/install-jx-on-gke/lesson.md
+++ b/tutorials/install-jx-on-gke/lesson.md
@@ -13,7 +13,7 @@ Click the **Continue** button to move to the next step.
 The first thing we need to do is install the `jx` binary and add it to your PATH.
 
 ```bash
-eval "$(./install-jx.sh)"
+./install-jx.sh
 ```
 
 **Tip**: Click the copy button on the side of the code box and paste the command in the Cloud Shell terminal to run it.


### PR DESCRIPTION
On a fresh project installation, the install script failed to add jx to the current cloudshell's path, so it would error out with:

`-bash: jx: command not found`

Also added some echo statements to let the user know stuff is happening during script execution.