### PR TITLE
Fix jx commands following install

### DIFF
--- a/install-guide.txt
+++ b/install-guide.txt
@@ -7,6 +7,6 @@
 To get started, you will need to install all required dependencies.  To do this
 run the script:
 
-`./install-jx.sh` to install jx and add it to you path.
+`source ./install-jx.sh` to install jx and add it to you path.
 
 Enjoy...

--- a/tutorials/install-jx-on-gke-with-terraform/lesson.md
+++ b/tutorials/install-jx-on-gke-with-terraform/lesson.md
@@ -6,14 +6,14 @@ This guide will show you how to install `jx` and use it to create a cluster on G
 
 **Time to complete**: About 30 minutes
 
-Click the **Continue** button to move to the next step.
+Click the **Next** button to move to the next step.
 
 ## Step 1 - Installing Dependencies
 
 The first thing we need to do is install the `jx` binary and add it to your PATH.
 
 ```bash
-./install-jx.sh
+source ./install-jx.sh
 ```
 
 **Tip**: Click the copy button on the side of the code box and paste the command in the Cloud Shell terminal to run it.

--- a/tutorials/install-jx-on-gke/lesson.md
+++ b/tutorials/install-jx-on-gke/lesson.md
@@ -6,14 +6,14 @@ This guide will show you how to install `jx` and use it to create a cluster on G
 
 **Time to complete**: About 25 minutes
 
-Click the **Continue** button to move to the next step.
+Click the **Next** button to move to the next step.
 
 ## Step 1 - Installing Dependencies
 
 The first thing we need to do is install the `jx` binary and add it to your PATH.
 
 ```bash
-./install-jx.sh
+source ./install-jx.sh
 ```
 
 **Tip**: Click the copy button on the side of the code box and paste the command in the Cloud Shell terminal to run it.


### PR DESCRIPTION
Following the exection of the install script the jx command is not found. Using source to execute the script resolves this.

Also changed to match cloud shell tutorial button text 'Next'