### PR TITLE
Added prerequisites to lesson too

### DIFF
--- a/tutorials/install-jx-on-gke/lesson.md
+++ b/tutorials/install-jx-on-gke/lesson.md
@@ -8,6 +8,18 @@ This guide will show you how to install `jx` and use it to create a cluster on G
 
 Click the **Next** button to move to the next step.
 
+## Prerequisites
+
+To run this tutorial you need to:
+
+  * Create and/or select a project.
+  
+      * To create a project: `gcloud projects create <project-name>`
+      
+      * To select the project in which this tutorial will be executed: `gcloud config set project <PROJECT_ID>`
+         
+  * Billing must be enabled (note there's a $300 credit, free tier for new accounts)
+
 ## Step 1 - Installing Dependencies
 
 The first thing we need to do is install the `jx` binary and add it to your PATH.


### PR DESCRIPTION
I was following the "Installing JX on GKE" tutorial, by clicking in the "Open in Google Cloud Shell" button from the [Jenkins X Tutorials page](https://jenkins-x.io/getting-started/tutorials/) and encountered a couple of issues when attempting to create a cluster.

After Googling a bit, I found [this issue](https://github.com/jenkins-x/jx-tutorial/issues/38) by @vilacides that made me realize that I had not created and set a project.

Even though I see that prerequisites were added to the README, I was following the tutorial that is displayed in the right hand side of Google Cloud Shell, which did not include a note on those prerequisites. Since I guess there are probably other like me out there, I thought it could be useful to add the prerequisites also in the "lesson" itself.